### PR TITLE
Fix `Marshal.dump(RBTree.new)`

### DIFF
--- a/rbtree.c
+++ b/rbtree.c
@@ -1521,7 +1521,7 @@ to_flatten_ary_i(dnode_t* node, void* ary)
  * Called by Marshal.dump.
  */
 VALUE
-rbtree_dump(VALUE self, VALUE limit)
+rbtree_dump(VALUE self)
 {
     VALUE ary;
     VALUE ret;
@@ -1535,7 +1535,7 @@ rbtree_dump(VALUE self, VALUE limit)
     rbtree_for_each(self, to_flatten_ary_i, (void*)ary);
     rb_ary_push(ary, IFNONE(self));
 
-    ret = rb_marshal_dump(ary, limit);
+    ret = rb_marshal_dump(ary, Qnil);
     rb_ary_clear(ary);
     rb_gc_force_recycle(ary);
     return ret;


### PR DESCRIPTION
I hit a bug with `Marshal.dump(SortedSet.new)` when `rbtree` is installed.

SortedSet uses RBTree when it's present:
https://github.com/ruby/ruby/blob/3a083985a471ca3d8429146f9f18dead6747c203/lib/set.rb#L710-L714

Because of that, any class that encapsulates a SortedSet is affected.

The bug happens because `rb_marshal_dump` doesn't accept `limit` as its second
argument:
https://github.com/ruby/ruby/blob/3a083985a471ca3d8429146f9f18dead6747c203/marshal.c#L2272

I'm no C Ruby API expert and I am not sure what `port` means but this change
does fix a failing test in this project.